### PR TITLE
챗봇 기능 추가 완료

### DIFF
--- a/src/main/java/com/example/eternaltalk/client/OpenAiClient.java
+++ b/src/main/java/com/example/eternaltalk/client/OpenAiClient.java
@@ -1,0 +1,65 @@
+// src/main/java/com/example/eternaltalk/client/OpenAiClient.java
+package com.example.eternaltalk.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public class OpenAiClient {
+
+    private final WebClient web;
+
+    public OpenAiClient(@Value("${OPENAI_API_KEY}") String apiKey) {
+        this.web = WebClient.builder()
+                .baseUrl("https://api.openai.com/v1")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .build();
+    }
+
+    /** Chat Completions 호출. system + user 메시지 → reply 텍스트 반환 */
+    public String chat(String model, String systemPrompt, String userText) {
+        String body = """
+        {
+          "model": "%s",
+          "messages": [
+            {"role": "system", "content": %s},
+            {"role": "user", "content": %s}
+          ]
+        }
+        """.formatted(
+                escape(model),
+                toJsonString(systemPrompt),
+                toJsonString(userText)
+        );
+
+        return web.post()
+                .uri("/chat/completions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, r -> r.bodyToMono(String.class)
+                        .flatMap(b -> Mono.error(new IllegalArgumentException("OpenAI 호출 실패: " + b))))
+                .bodyToMono(OpenAiChatResponse.class)
+                .map(resp -> {
+                    if (resp.choices() == null || resp.choices().length == 0
+                            || resp.choices()[0].message() == null) return "";
+                    return resp.choices()[0].message().content();
+                })
+                .block();
+    }
+
+    // ---- 응답 모델 ----
+    public record OpenAiChatResponse(OpenAiChoice[] choices) {}
+    public record OpenAiChoice(OpenAiMessage message) {}
+    public record OpenAiMessage(String role, String content) {}
+
+    // ---- Helpers ----
+    private static String escape(String s){ return s.replace("\\","\\\\").replace("\"","\\\""); }
+    private static String toJsonString(String s){
+        if (s == null) s = "";
+        return "\"" + escape(s).replace("\n","\\n") + "\"";
+    }
+}

--- a/src/main/java/com/example/eternaltalk/controller/ChatController.java
+++ b/src/main/java/com/example/eternaltalk/controller/ChatController.java
@@ -1,0 +1,37 @@
+// src/main/java/com/example/eternaltalk/controller/ChatController.java
+package com.example.eternaltalk.controller;
+
+import com.example.eternaltalk.dto.ChatDtos;
+import com.example.eternaltalk.security.SecurityUtils;
+import com.example.eternaltalk.service.ChatService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class ChatController {
+
+    private final ChatService service;
+    public ChatController(ChatService service){ this.service = service; }
+
+    // PUT /api/memory/profile
+    @PutMapping("/memory/profile")
+    public ChatDtos.UpsertProfileResponse upsertProfile(@Valid @RequestBody ChatDtos.UpsertProfileRequest req){
+        String email = SecurityUtils.currentUserEmailOrThrow();
+        return service.upsertProfile(email, req.displayName, req.personalityPrompt);
+    }
+
+    // POST /api/chat/send
+    @PostMapping("/chat/send")
+    public ChatDtos.SendResponse send(@Valid @RequestBody ChatDtos.SendRequest req){
+        String email = SecurityUtils.currentUserEmailOrThrow();
+        return service.send(email, req.text);
+    }
+
+    // GET /api/chat/quota
+    @GetMapping("/chat/quota")
+    public ChatDtos.QuotaResponse quota(){
+        String email = SecurityUtils.currentUserEmailOrThrow();
+        return service.quota(email);
+    }
+}

--- a/src/main/java/com/example/eternaltalk/domain/chat/ChatUsageDaily.java
+++ b/src/main/java/com/example/eternaltalk/domain/chat/ChatUsageDaily.java
@@ -1,0 +1,27 @@
+// src/main/java/com/example/eternaltalk/domain/chat/ChatUsageDaily.java
+package com.example.eternaltalk.domain.chat;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "chat_usage_daily",
+        uniqueConstraints = @UniqueConstraint(name="uk_chat_usage_daily_user_date",
+                columnNames = {"user_id","usage_date"}))
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class ChatUsageDaily {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="user_id", nullable=false)
+    private Long userId;
+
+    @Column(name="usage_date", nullable=false)
+    private LocalDate usageDate;
+
+    @Column(name="used_chars", nullable=false)
+    private int usedChars;
+}

--- a/src/main/java/com/example/eternaltalk/domain/memory/MemoryProfile.java
+++ b/src/main/java/com/example/eternaltalk/domain/memory/MemoryProfile.java
@@ -21,6 +21,12 @@ public class MemoryProfile {
     @Column(name="photo_url")
     private String photoUrl;
 
+    @Column(name = "display_name")
+    private String displayName;
+
+    @Column(name = "personality_prompt", columnDefinition = "TEXT")
+    private String personalityPrompt;
+
     private LocalDateTime updatedAt;
 
     @PrePersist @PreUpdate

--- a/src/main/java/com/example/eternaltalk/dto/ChatDtos.java
+++ b/src/main/java/com/example/eternaltalk/dto/ChatDtos.java
@@ -1,0 +1,38 @@
+// src/main/java/com/example/eternaltalk/dto/ChatDtos.java
+package com.example.eternaltalk.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class ChatDtos {
+
+    // PUT /api/memory/profile
+    public static class UpsertProfileRequest {
+        @NotBlank(message = "displayName은 필수입니다.")
+        public String displayName;
+        @NotBlank(message = "personalityPrompt는 필수입니다.")
+        public String personalityPrompt;
+    }
+    public static class UpsertProfileResponse {
+        public String displayName;
+        public String personalityPrompt;
+        public UpsertProfileResponse(String n, String p){ this.displayName = n; this.personalityPrompt = p; }
+    }
+
+    // POST /api/chat/send
+    public static class SendRequest {
+        @NotBlank(message = "text는 필수입니다.")
+        public String text;
+    }
+    public static class SendResponse {
+        public String reply;
+        public int remainingCharsToday;
+        public SendResponse(String reply, int remaining){ this.reply = reply; this.remainingCharsToday = remaining; }
+    }
+
+    // GET /api/chat/quota
+    public static class QuotaResponse {
+        public int remainingCharsToday;
+        public int planLimit;
+        public QuotaResponse(int remaining, int planLimit){ this.remainingCharsToday = remaining; this.planLimit = planLimit; }
+    }
+}

--- a/src/main/java/com/example/eternaltalk/repository/ChatUsageDailyRepository.java
+++ b/src/main/java/com/example/eternaltalk/repository/ChatUsageDailyRepository.java
@@ -1,0 +1,12 @@
+// src/main/java/com/example/eternaltalk/repository/ChatUsageDailyRepository.java
+package com.example.eternaltalk.repository;
+
+import com.example.eternaltalk.domain.chat.ChatUsageDaily;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface ChatUsageDailyRepository extends JpaRepository<ChatUsageDaily, Long> {
+    Optional<ChatUsageDaily> findByUserIdAndUsageDate(Long userId, LocalDate usageDate);
+}

--- a/src/main/java/com/example/eternaltalk/service/ChatService.java
+++ b/src/main/java/com/example/eternaltalk/service/ChatService.java
@@ -1,0 +1,154 @@
+// src/main/java/com/example/eternaltalk/service/ChatService.java
+package com.example.eternaltalk.service;
+
+import com.example.eternaltalk.client.OpenAiClient;
+import com.example.eternaltalk.domain.User;
+import com.example.eternaltalk.domain.chat.ChatUsageDaily;
+import com.example.eternaltalk.domain.memory.MemoryProfile;
+import com.example.eternaltalk.dto.ChatDtos;
+import com.example.eternaltalk.repository.ChatUsageDailyRepository;
+import com.example.eternaltalk.repository.MemoryProfileRepository;
+import com.example.eternaltalk.repository.UserRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Service
+public class ChatService {
+
+    private final UserRepository userRepository;
+    private final MemoryProfileRepository memoryProfileRepository;
+    private final ChatUsageDailyRepository chatUsageDailyRepository;
+    private final OpenAiClient openAi;
+
+    // 기본 모델 (필요하면 설정값으로 변경)
+    private static final String DEFAULT_MODEL = "gpt-4o-mini";
+
+    public ChatService(UserRepository userRepository,
+                       MemoryProfileRepository memoryProfileRepository,
+                       ChatUsageDailyRepository chatUsageDailyRepository,
+                       OpenAiClient openAi) {
+        this.userRepository = userRepository;
+        this.memoryProfileRepository = memoryProfileRepository;
+        this.chatUsageDailyRepository = chatUsageDailyRepository;
+        this.openAi = openAi;
+    }
+
+    // 1) 프로필 업서트
+    public ChatDtos.UpsertProfileResponse upsertProfile(String email, String displayName, String personalityPrompt){
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        MemoryProfile mp = memoryProfileRepository.findByUserId(user.getId())
+                .orElseGet(() -> MemoryProfile.builder().userId(user.getId()).build());
+        mp.setDisplayName(displayName);
+        mp.setPersonalityPrompt(personalityPrompt);
+        memoryProfileRepository.save(mp);
+
+        return new ChatDtos.UpsertProfileResponse(mp.getDisplayName(), mp.getPersonalityPrompt());
+    }
+
+    // 2) 채팅 전송 (일일 글자 제한 검사)
+    public ChatDtos.SendResponse send(String email, String userText){
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Plan plan = resolvePlan(user); // FREE/SILVER/GOLD
+        int limit = plan.dailyLimit;
+
+        int todayUsed = chatUsageDailyRepository.findByUserIdAndUsageDate(user.getId(), LocalDate.now())
+                .map(ChatUsageDaily::getUsedChars).orElse(0);
+
+        int inputCount = countCharacters(userText); // 기본: 공백 제외 코드포인트 수
+        if (todayUsed + inputCount > limit) {
+            int remaining = Math.max(0, limit - todayUsed);
+            throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS,
+                    "일일 입력 글자 제한 초과 (남은 글자: " + remaining + ", 요금제: " + plan.name() + ")");
+        }
+
+        // 시스템 프롬프트 구성: displayName + personalityPrompt
+        MemoryProfile mp = memoryProfileRepository.findByUserId(user.getId())
+                .orElse(null);
+
+        String systemPrompt = buildSystemPrompt(mp);
+
+        // OpenAI 호출
+        String reply = openAi.chat(DEFAULT_MODEL, systemPrompt, userText);
+
+        // 사용량 반영
+        ChatUsageDaily row = chatUsageDailyRepository.findByUserIdAndUsageDate(user.getId(), LocalDate.now())
+                .orElseGet(() -> ChatUsageDaily.builder()
+                        .userId(user.getId())
+                        .usageDate(LocalDate.now())
+                        .usedChars(0)
+                        .build());
+        row.setUsedChars(row.getUsedChars() + inputCount);
+        chatUsageDailyRepository.save(row);
+
+        int remaining = Math.max(0, limit - row.getUsedChars());
+        return new ChatDtos.SendResponse(reply, remaining);
+    }
+
+    // 3) 잔여 쿼터 조회
+    public ChatDtos.QuotaResponse quota(String email){
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        Plan plan = resolvePlan(user);
+        int used = chatUsageDailyRepository.findByUserIdAndUsageDate(user.getId(), LocalDate.now())
+                .map(ChatUsageDaily::getUsedChars).orElse(0);
+        int remaining = Math.max(0, plan.dailyLimit - used);
+        return new ChatDtos.QuotaResponse(remaining, plan.dailyLimit);
+    }
+
+    // ---- Helpers ----
+
+    /** FREE=100, SILVER=500, GOLD=700 */
+    private enum Plan {
+        FREE(100), SILVER(500), GOLD(700);
+        final int dailyLimit; Plan(int v){ this.dailyLimit = v; }
+        static Plan safe(String s){
+            try { return Plan.valueOf(s.toUpperCase()); } catch (Exception e){ return FREE; }
+        }
+    }
+
+    /** User 엔티티에 plan/membership/tier 중 존재하는 필드를 찾아 사용. 없으면 FREE */
+    private Plan resolvePlan(User user){
+        for (String fieldName : new String[]{"plan", "membership", "tier"}) {
+            try {
+                Field f = user.getClass().getDeclaredField(fieldName);
+                f.setAccessible(true);
+                Object v = f.get(user);
+                if (v != null) return Plan.safe(v.toString());
+            } catch (Exception ignore) {}
+        }
+        return Plan.FREE;
+    }
+
+    /** 공백 제외 글자수(코드포인트) 카운트 */
+    private int countCharacters(String text){
+        if (text == null) return 0;
+        int i = 0, n = text.length(), c = 0;
+        while (i < n){
+            int cp = text.codePointAt(i);
+            i += Character.charCount(cp);
+            if (Character.isWhitespace(cp)) continue; // 공백 제외
+            c++;
+        }
+        return c;
+    }
+
+    private String buildSystemPrompt(MemoryProfile mp){
+        String name = (mp != null && mp.getDisplayName() != null) ? mp.getDisplayName().trim() : "고인";
+        String persona = (mp != null && mp.getPersonalityPrompt() != null) ? mp.getPersonalityPrompt().trim() : "";
+        return """
+        당신은 '%s'의 말투와 성격을 반영해 대화합니다.
+        - 인격 설명: %s
+        - 사용자에게 위로와 공감을 우선합니다.
+        - 과장 없이 담백하고 진심 어린 어조를 유지합니다.
+        """.formatted(name, persona.isEmpty() ? "설정 없음" : persona);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,8 +42,8 @@ security:
 
 # ====== 음성 합성/스토리지 환경변수 ======
 ELEVENLABS_API_KEY: ${ELEVENLABS_API_KEY}
-
 DID_API_KEY: ${DID_API_KEY}
+OPENAI_API_KEY: ${OPENAI_API_KEY}
 
 S3_REGION: ${S3_REGION}
 S3_BUCKET: ${S3_BUCKET}


### PR DESCRIPTION
챗봇 기능
PUT /api/memory/profile
고인의 이름·성격 프롬프트 저장 → memory_profile 갱신 → { displayName } 반환

POST /api/chat/send
사용자 입력 텍스트 → displayName+personalityPrompt 결합 → OpenAI Chat Completions 호출 → { reply, remainingCharsToday } 반환

GET /api/chat/quota
오늘 사용 글자 수 / 남은 글자 수 확인 → { plan, dailyLimit, usedToday, remainingCharsToday } 반환

동작 흐름

로그인 사용자 이메일 조회
→ memory_profile 불러오기
→ 시스템 프롬프트 구성(displayName+personalityPrompt)
→ OpenAI Chat API 호출
→ 응답 저장 및 quota 차감
→ 남은 글자 수 반환

요금제 규칙
FREE: 100자/일
SILVER: 500자/일
GOLD: 700자/일
제한 초과 시 429 + 남은 글자 수 반환